### PR TITLE
create: ssr用のoac lambdaの作成とcloudfrontのdistribution大幅変更

### DIFF
--- a/modules/core/cloudfront.tf
+++ b/modules/core/cloudfront.tf
@@ -46,15 +46,15 @@ resource "aws_cloudfront_distribution" "main" {
 
   ### SSR
   origin {
-    domain_name        = replace(replace(aws_lambda_function_url.internal_wanrun_ssr.function_url, "https://", ""), "/", "")
-    origin_id = aws_lambda_function.internal_wanrun_ssr.function_name
+    domain_name = replace(replace(aws_lambda_function_url.internal_wanrun_ssr.function_url, "https://", ""), "/", "")
+    origin_id   = aws_lambda_function.internal_wanrun_ssr.function_name
 
     # oac
     origin_access_control_id = aws_cloudfront_origin_access_control.internal_wanrun_ssr.id
 
     custom_origin_config {
-      http_port = 80
-      https_port = 443
+      http_port              = 80
+      https_port             = 443
       origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }

--- a/modules/core/cloudfront.tf
+++ b/modules/core/cloudfront.tf
@@ -11,8 +11,57 @@ resource "aws_cloudfront_distribution" "main" {
     origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
   }
 
+  # `/static/*`, `/assets/*`だけS3に振り分ける
+  ordered_cache_behavior {
+    path_pattern           = "/static/*"
+    target_origin_id       = "s3-static-site"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_optimized.id
+  }
+
+  ordered_cache_behavior {
+    path_pattern           = "/assets/*"
+    target_origin_id       = "s3-static-site"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_optimized.id
+  }
+
+  # defaultをLambdaに変更
+  # default_cache_behavior {
+  #   target_origin_id       = aws_s3_bucket.web.bucket_regional_domain_name
+  #   viewer_protocol_policy = "redirect-to-https"
+  #   allowed_methods        = ["GET", "HEAD"]
+  #   cached_methods         = ["GET", "HEAD"]
+  #   compress               = true
+
+  #   # 各policy設定
+  #   response_headers_policy_id = aws_cloudfront_response_headers_policy.frontend.id
+  #   origin_request_policy_id   = aws_cloudfront_origin_request_policy.frontend.id
+  #   cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
+  # }
+
+  ### SSR
+  origin {
+    domain_name        = replace(replace(aws_lambda_function_url.internal_wanrun_ssr.function_url, "https://", ""), "/", "")
+    origin_id = aws_lambda_function.internal_wanrun_ssr.function_name
+
+    # oac
+    origin_access_control_id = aws_cloudfront_origin_access_control.internal_wanrun_ssr.id
+
+    custom_origin_config {
+      http_port = 80
+      https_port = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
   default_cache_behavior {
-    target_origin_id       = aws_s3_bucket.web.bucket_regional_domain_name
+    target_origin_id       = aws_lambda_function.internal_wanrun_ssr.function_name
     viewer_protocol_policy = "redirect-to-https"
     allowed_methods        = ["GET", "HEAD"]
     cached_methods         = ["GET", "HEAD"]
@@ -21,13 +70,7 @@ resource "aws_cloudfront_distribution" "main" {
     # 各policy設定
     response_headers_policy_id = aws_cloudfront_response_headers_policy.frontend.id
     origin_request_policy_id   = aws_cloudfront_origin_request_policy.frontend.id
-    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
-
-    # ssr用
-    lambda_function_association {
-      event_type = "viewer-request"
-      lambda_arn = aws_lambda_function.wanrun_ssr.qualified_arn
-    }
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id // NOTE: ssrなので、キャッシュなし
   }
 
   ### gateway側
@@ -164,10 +207,21 @@ resource "aws_cloudfront_origin_request_policy" "frontend" {
   }
 }
 
+#######################################################################
 # OAC
+#######################################################################
+## S3
 resource "aws_cloudfront_origin_access_control" "frontend" {
   name                              = "${var.service_name}-${var.env}-oac"
   origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+## lambda
+resource "aws_cloudfront_origin_access_control" "internal_wanrun_ssr" {
+  name                              = "${var.service_name}-${var.env}-internal-wanrun-ssr-oac"
+  origin_access_control_origin_type = "lambda"
   signing_behavior                  = "always"
   signing_protocol                  = "sigv4"
 }

--- a/modules/core/data.tf
+++ b/modules/core/data.tf
@@ -8,3 +8,5 @@ data "aws_cloudfront_cache_policy" "caching_optimized" {
 data "aws_cloudfront_cache_policy" "caching_disabled" {
   name = "Managed-CachingDisabled"
 }
+
+data "aws_caller_identity" "current" {}

--- a/modules/core/lambda.tf
+++ b/modules/core/lambda.tf
@@ -16,10 +16,14 @@ resource "aws_lambda_function" "internal_wanrun_ssr" {
     subnet_ids         = var.private_subnet_ids
     security_group_ids = var.lambda_sg_ids
   }
+
+  lifecycle {
+    ignore_changes = [ image_uri ]
+  }
 }
 
 resource "aws_lambda_function_url" "internal_wanrun_ssr" {
-  function_name      = aws_lambda_function.wanrun_ssr.function_name
+  function_name      = aws_lambda_function.internal_wanrun_ssr.function_name
   authorization_type = "AWS_IAM"
 }
 

--- a/modules/core/lambda.tf
+++ b/modules/core/lambda.tf
@@ -5,12 +5,12 @@ resource "aws_lambda_function" "internal_wanrun_ssr" {
   function_name = "${var.service_name}-${var.env}-internal-wanrun-ssr"
   description   = "Server Side Rendering"
 
-  role    = aws_iam_role.wanrun_ssr.arn
+  role         = aws_iam_role.wanrun_ssr.arn
   package_type = "Image"
   image_uri    = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-1.amazonaws.com/lambda-initialize:latest"
 
   memory_size = "128"
-  timeout = "60"
+  timeout     = "60"
 
   vpc_config {
     subnet_ids         = var.private_subnet_ids
@@ -18,7 +18,7 @@ resource "aws_lambda_function" "internal_wanrun_ssr" {
   }
 
   lifecycle {
-    ignore_changes = [ image_uri ]
+    ignore_changes = [image_uri]
   }
 }
 

--- a/modules/core/lambda.tf
+++ b/modules/core/lambda.tf
@@ -1,5 +1,6 @@
 #######################################################################
 # wanrun server side rendering
+# NOTE: https://qiita.com/j2-yano/items/3aba0f546820927b70c7
 #######################################################################
 resource "aws_lambda_function" "internal_wanrun_ssr" {
   function_name = "${var.service_name}-${var.env}-internal-wanrun-ssr"

--- a/modules/core/lambda.tf
+++ b/modules/core/lambda.tf
@@ -1,27 +1,34 @@
-
 #######################################################################
 # wanrun server side rendering
 #######################################################################
-resource "aws_lambda_function" "wanrun_ssr" {
-  provider      = aws.virginia
-  function_name = "${var.service_name}-${var.env}-wanrun-ssr"
+resource "aws_lambda_function" "internal_wanrun_ssr" {
+  function_name = "${var.service_name}-${var.env}-internal-wanrun-ssr"
   description   = "Server Side Rendering"
 
   role    = aws_iam_role.wanrun_ssr.arn
-  handler = "index.handler"
-  runtime = "nodejs20.x"
+  package_type = "Image"
+  image_uri    = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-1.amazonaws.com/lambda-initialize:latest"
 
-  publish = true
+  memory_size = "128"
+  timeout = "60"
 
-  filename         = data.archive_file.wanrun_ssr.output_path
-  source_code_hash = data.archive_file.wanrun_ssr.output_base64sha256
+  vpc_config {
+    subnet_ids         = var.private_subnet_ids
+    security_group_ids = var.lambda_sg_ids
+  }
 }
 
-# NOTE: 別リポジトリでコード管理とCI/CDを置くため、temporary
-data "archive_file" "wanrun_ssr" {
-  type        = "zip"
-  source_dir  = "${path.module}/function/temporary"
-  output_path = "${path.module}/function/.zip/temporary.zip"
+resource "aws_lambda_function_url" "internal_wanrun_ssr" {
+  function_name      = aws_lambda_function.wanrun_ssr.function_name
+  authorization_type = "AWS_IAM"
+}
+
+resource "aws_lambda_permission" "internal_wanrun_ssr" {
+  statement_id  = "AllowCloudFrontServicePrincipal"
+  action        = "lambda:InvokeFunctionUrl"
+  function_name = aws_lambda_function.internal_wanrun_ssr.function_name
+  principal     = "cloudfront.amazonaws.com"
+  source_arn    = aws_cloudfront_distribution.main.arn
 }
 
 #######################################################################
@@ -38,7 +45,6 @@ data "aws_iam_policy_document" "lambda_edge_assume_role_policy" {
       type = "Service"
 
       identifiers = [
-        "edgelambda.amazonaws.com",
         "lambda.amazonaws.com",
       ]
     }
@@ -59,6 +65,17 @@ data "aws_iam_policy_document" "wanrun_ssr" {
       "logs:PutLogEvents",
       "logs:CreateLogGroup"
     ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "lambda:InvokeFunction",
+      "lambda:GetFunction",
+      "lambda:EnableReplication",
+      "cloudfront:UpdateDistribution"
+    ]
+    resources = ["*"]
   }
 }
 

--- a/modules/core/variable.tf
+++ b/modules/core/variable.tf
@@ -131,3 +131,8 @@ variable "ssm_prefix" {
   type    = string
   default = ""
 }
+
+variable "lambda_sg_ids" {
+  type    = list(string)
+  default = []
+}


### PR DESCRIPTION
## 概要
ssr用のoac lambdaの作成とcloudfrontのdistribution大幅変更
## 変更点
- lambda@edgeだと制約でできないため、OACのLambdaに変更
- defaultのビヘイビアをS3からLambdaに変更
- S3のパスは、static部分のみに変更
## 関連Issue
- 関連Issue: #55