### PR TITLE
fix remove default root object

### DIFF
--- a/modules/core/cloudfront.tf
+++ b/modules/core/cloudfront.tf
@@ -106,7 +106,7 @@ resource "aws_cloudfront_distribution" "main" {
 
   is_ipv6_enabled     = true
   price_class         = "PriceClass_200" // PriceClass_100
-  default_root_object = "index.html"
+  # default_root_object = "index.html" // SSR側で用意されるので不要
   #   web_acl_id          = var.main_waf_acl_id // NOTE: 現状WAFなしで進める
 
   // 国の指定


### PR DESCRIPTION
## 概要
SSR側のルートページを開くためにCloudFrontのdefault root objectを除く